### PR TITLE
rlp: decode long hex

### DIFF
--- a/src/abi.c
+++ b/src/abi.c
@@ -136,8 +136,38 @@ int eth_abi_free(struct eth_abi *abi) {
   if (abi == NULL)
     return -1;
 
-  free(abi->cframe);
-  abi->cframe = NULL;
+  if (abi->cframe != NULL) {
+    struct ethc_abi_frame *frame = abi->cframe;
+    while (frame) {
+      int i;
+      struct ethc_abi_frame *curr = frame;
+
+      if (frame->buf != NULL) {
+        if (frame->buf->buf != NULL) {
+          free(frame->buf->buf);
+          frame->buf->buf = NULL;
+        }
+        free(frame->buf);
+        frame->buf = NULL;
+      }
+
+      for (i = 0; i < frame->dybuflen; i++) {
+        struct ethc_abi_buf *dybuf = frame->dybufs[i];
+        if (dybuf != NULL) {
+          if (dybuf->buf != NULL) {
+            free(dybuf->buf);
+            dybuf->buf = NULL;
+          }
+          free(dybuf);
+          dybuf = NULL;
+        }
+      }
+
+      frame = frame->pframe;
+      free(curr);
+      curr = NULL;
+    }
+  }
   return 1;
 }
 

--- a/test/run-tests.c
+++ b/test/run-tests.c
@@ -56,6 +56,7 @@ int main() {
   test_eth_rlp_address();
   test_eth_rlp_to_hex();
   test_eth_rlp_to_bytes();
+  test_eth_rlp_decode_eip1559_tx();
   test_eth_abi_mpint();
 
   done_testing();

--- a/test/test.h
+++ b/test/test.h
@@ -58,3 +58,4 @@ void test_eth_rlp_bytes(void);
 void test_eth_rlp_hex(void);
 void test_eth_rlp_to_hex(void);
 void test_eth_rlp_to_bytes(void);
+void test_eth_rlp_decode_eip1559_tx(void);


### PR DESCRIPTION
Hi, I found that RLP decoding fails when parsing long encoded string, so I modified the `eth_rlp_len` function and unit-tested it with an EIP-1559 transaction.  It seems to be working fine.

But there are two things I'm not sure about:
+ In `eth_rlp_array` and `eth_rlp_bytes`, the checking of base values is removed. Maybe the better way is to check all possible values?
+ In `eth_rlp_hex` and `eth_rlp_uint8/16/32/64`, the default value of 0 is returned when `blen` is 0 (i.e. `0x80`).

Besides, a free issue that could lead to memory leaks is fixed.

Please review the PR and feel free to comment. I'll fix it as soon as possible.