### PR TITLE
rlp: eth_rlp_address() should support empty address

### DIFF
--- a/src/rlp.c
+++ b/src/rlp.c
@@ -494,7 +494,7 @@ int eth_rlp_address(struct eth_rlp *rlp, char **addr) {
 
   if (rlp->m == ETH_RLP_ENCODE) {
     if (*addr == NULL || strlen(*addr) == 0) {
-      // Handle empty address, support deploy contract.
+      /* Handle empty address, support deploy contract. */
       uint8_t empty_address = 0x00;
       uint8_t *empty_address_ptr = &empty_address;
       size_t size = 1;
@@ -519,18 +519,18 @@ int eth_rlp_address(struct eth_rlp *rlp, char **addr) {
     size_t hsize;
 
     if (eth_rlp_bytes(rlp, &buf, &hsize) <= 0)
-        return -1;
+      return -1;
 
-    if (hsize == 1 && buf[0] == 0x80) {
-        // Handle empty address
-        *addr = strdup("");
-        free(buf);
-        return 1;
+    if (hsize == 1 && buf[0] == 0x0) {
+      /* Handle empty address */
+      *addr = strdup("");
+      free(buf);
+      return 1;
     }
 
     if ((hsize = (size_t)eth_hex_from_bytes(addr, buf, hsize)) <= 0) {
-        free(buf);
-        return -1;
+      free(buf);
+      return -1;
     }
 
     free(buf);

--- a/test/test-eth-rlp.c
+++ b/test/test-eth-rlp.c
@@ -189,9 +189,11 @@ void test_eth_rlp_hex(void) {
 }
 
 void test_eth_rlp_address(void) {
-  struct eth_rlp rlp0, rlp1;
+  struct eth_rlp rlp0, rlp1, rlp_empty;
   char *addr0 = "0x86C4dDdd08F8153E50247eaB59e500c043F99BfF",
-       *addr1, *hex0;
+       *addr1, *hex0, *hex_empty;
+  char *empty_addr = "";
+  char *decoded_addr;
 
   ok(eth_rlp_init(&rlp0, ETH_RLP_ENCODE) == 1);
   ok(eth_rlp_array(&rlp0) == 1);
@@ -212,6 +214,23 @@ void test_eth_rlp_address(void) {
 
   is(addr1, "86c4dddd08f8153e50247eab59e500c043f99bff");
   free(addr1);
+
+  /* Test encoding empty address */
+  ok(eth_rlp_init(&rlp0, ETH_RLP_ENCODE) == 1);
+  ok(eth_rlp_address(&rlp0, &empty_addr) == 1);
+  ok(eth_rlp_to_hex(&hex_empty, &rlp0) > 0);
+  ok(eth_rlp_to_hex(&hex_empty, &rlp0) > 0);
+  ok(eth_rlp_to_hex(&hex_empty, &rlp0) > 0);
+  ok(eth_rlp_free(&rlp0) == 1);
+  is(hex_empty, "80");
+  free(hex_empty);
+
+  /* Test decoding empty address */
+  ok(eth_rlp_from_hex(&rlp_empty, hex_empty, -1) == 1);
+  ok(eth_rlp_address(&rlp_empty, &decoded_addr) == 1);
+  ok(eth_rlp_free(&rlp_empty) == 1);
+  is(decoded_addr, "");
+  free(decoded_addr);
 }
 
 void test_eth_rlp_to_hex(void) {


### PR DESCRIPTION
Hello, brother. When I tried to deploy a contract using legacy tx, I encountered an error because eth_rlp_address() doesn't support empty addresses. I try to fix it, and it works correctly on my machine.