### PR TITLE
Fix memory allocation for hex string in rlp.c

### DIFF
--- a/examples/eip1559-transaction.c
+++ b/examples/eip1559-transaction.c
@@ -91,7 +91,7 @@ int main(void) {
 
   int tx_size = strlen(txn);
   int tx_prefix_size = strlen(tx_type_prefix_str);
-  char signed_tx[tx_size + tx_prefix_size];
+  char signed_tx[tx_size + tx_prefix_size + 1];
   sprintf(signed_tx, "%s%s", tx_type_prefix_str, txn);
 
   printf("EIP-1559 Signed transaction is:\n%s\n", signed_tx);

--- a/src/rlp.c
+++ b/src/rlp.c
@@ -337,7 +337,7 @@ ETH_OP eth_rlp_hex(struct eth_rlp *rlp, char **hex, int *len) {
       return op;
 
     if (hsize == 0) {
-      *hex = "0";
+      *hex = strdup("0");
     } else if ((hsize = (size_t)eth_hex_from_bytes(hex, buf, hsize)) <= 0) {
       return ETH_ERR_INVALID_ARGS;
     }


### PR DESCRIPTION
In rlp.c, the eth_rlp_hex method returns a pointer to the global area when decoding if the length is 0, and a pointer to heap space if the length is non-zero. This makes it impossible for callers of eth_rlp_hex to uniformly determine whether and how to release this memory block. Therefore, it is recommended to modify the method to consistently return a pointer to heap space.